### PR TITLE
Add: 教育費のデータをpublic/education_cost.jsonに保存した。#9

### DIFF
--- a/public/education_cost.json
+++ b/public/education_cost.json
@@ -22,8 +22,5 @@
     "private_litelature": 6898000,
     "private_science": 8216000
   },
-  "living_alone_funds": {
-    "initial_cost": 387000,
-    "month_funds": 80000
-  }
+  "living_alone_funds": 4179000
 }


### PR DESCRIPTION
概要
教育費シュミレーションで使用する教育費用のデータをJSONで作成しました。
当初はMySQLに保存する予定でしたが、
* レスポンス時間の短縮のため、シュミレーション機能は非同期で行いたかったから。
* データが階層化しており、リレーショナルデータベースでの保存が適さないと判断したから。
* データは読み取り専用で、変更や追加をすることは数年に一度程度だから。
以上の理由から、JSON形式でのデータ保存を選択しました。

なおJSONファイルは慣例に則り、public配下に保存することとします。