### PR TITLE
Payment form with plan content

### DIFF
--- a/app/controllers/payment_collections_controller.rb
+++ b/app/controllers/payment_collections_controller.rb
@@ -5,8 +5,8 @@ class PaymentCollectionsController < ApplicationController
   end
 
   def new
-    @payment_collection = PaymentCollection.new
-    3.times.each { @payment_collection.payments.push(Payment.new) }
+    @payment_collection = PaymentCollection.new(paymented_at: Date.today)
+    @payment_collection.get_payments_with_plans(@child)
   end
 
   def create

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -11,7 +11,7 @@ class PlansController < ApplicationController
   def create
     @form = PlanForm.new(plan_form_params)
     if @form.save
-      redirect_to child_plans_path, success: '入金設定しました'
+      redirect_to child_plans_path, success: '積立情報設定しました'
     else
       flash.now[:danger] = '入力項目を確認してください'
       render :new
@@ -30,7 +30,7 @@ class PlansController < ApplicationController
       plan_ids.each do |id|
         Plan.destroy(id)
       end
-      redirect_to child_plans_path, success: '入金設定を編集しました'
+      redirect_to child_plans_path, success: '積立情報設定を編集しました'
     else
       flash.now[:danger] = '入力項目を確認してください'
       render :edit
@@ -40,7 +40,7 @@ class PlansController < ApplicationController
   def destroy
     plan = current_user.current_child.plans.find(params[:id])
     plan.destroy!
-    redirect_to child_plans_path(current_user.current_child), success: '入金設定を削除しました'
+    redirect_to child_plans_path(current_user.current_child), success: '積立情報設定を削除しました'
   end
 
   private

--- a/app/models/payment_collection.rb
+++ b/app/models/payment_collection.rb
@@ -6,4 +6,13 @@ class PaymentCollection < ApplicationRecord
   validates :paymented_at, presence: true
 
   scope :by_recently_paymented_at, -> { order(paymented_at: :desc) }
+
+  def get_payments_with_plans(child)
+    3.times.each { payments.push(Payment.new) }
+    plans = child.plans
+    plans.each_with_index do |plan, idx|
+      payments[idx].item = plan.item
+      payments[idx].amount = plan.amount
+    end
+  end
 end

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -58,7 +58,10 @@
       </div>
     </div>
   <% else %>
-    <p class='text-center text-amber-dark'>データはありません</p>
+    <div class='text-center'>
+      <p class='text-center text-amber-dark mb-3'>データはありません</p>
+      <%= link_to '積立情報設定の新規登録', new_child_plan_path(@child), class: 'px-3 py-2 bg-amber-vivid text-white rounded-md shadow-md hover:shadow-sm' unless @child.plans.present? %>
+    </div>
   <% end %>
   <% if @child.result.present? %>
       <div class='mb-10'>

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -1,3 +1,3 @@
-<h1 class='text-3xl text-amber-dark text-center mb-5'>入金設定編集</h1>
+<h1 class='text-3xl text-amber-dark text-center mb-5'>積立情報設定編集</h1>
 
 <%= render 'plan_form', form: @form, path: child_plans_path(@child.id), method: :patch %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,10 +1,10 @@
-<h1 class='mb-5 text-3xl text-amber-dark text-center'>入金設定一覧</h1>
+<h1 class='mb-5 text-3xl text-amber-dark text-center'>積立情報設定一覧</h1>
 
 <% if @child.plans.empty? %>
   <div class='text-center'>
     <p class='text-amber-dark'>何もデータはありません</p>
     <div class='mt-3'>
-      <%= link_to '入金設定の新規登録', new_child_plan_path(@child), class: 'px-3 py-2 bg-amber-vivid text-white rounded-md shadow-md hover:shadow-sm' %>
+      <%= link_to '積立情報設定の新規登録', new_child_plan_path(@child), class: 'px-3 py-2 bg-amber-vivid text-white rounded-md shadow-md hover:shadow-sm' %>
     </div>
   </div>
 <% else %>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -1,3 +1,3 @@
-<h1 class='text-3xl text-amber-dark text-center mb-5'>入金設定登録</h1>
+<h1 class='text-3xl text-amber-dark text-center mb-5'>積立情報設定登録</h1>
 
 <%= render 'plan_form', form: @form, path: child_plans_path(@child.id), method: :post %>

--- a/app/views/shared/_submenu.html.erb
+++ b/app/views/shared/_submenu.html.erb
@@ -7,7 +7,7 @@
       <li class="px-5 py-3 hover:bg-gray-100<%= ' underline bg-gray-200' if current_page?(child_payment_collections_path(@child)) %>">履歴</li>
     <% end %>
     <%= link_to child_plans_path(@child) do %>
-      <li class="px-5 py-3 hover:bg-gray-100<%= ' underline bg-gray-200' if current_page?(child_plans_path(@child)) || current_page?(new_child_plan_path(@child)) %>">入金設定</li>
+      <li class="px-5 py-3 hover:bg-gray-100<%= ' underline bg-gray-200' if current_page?(child_plans_path(@child)) || current_page?(new_child_plan_path(@child)) %>">積立情報設定</li>
     <% end %>
     <!-- li class='mb-3'>お子様情報追加</li>
     <li class='mb-3'>パートナー追加</li>

--- a/spec/system/payments_spec.rb
+++ b/spec/system/payments_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe "Payments", type: :system do
         expect(page).to have_content '入金に失敗しました'
       end
     end
+    fcontext 'form with registered plans' do
+      let!(plan_1){ create(:plan, item: '保険', amount: 20000, child: child) }
+      let!(plan_2){ create(:plan, item: '投資', amount: 10000, child: child) }
+      it 'can be displayed' do
+        expect(page).to have_content plan_1.item
+        expect(page).to have_content plan_1.amount
+        expect(page).to have_content plan_2.item
+        expect(page).to have_content plan_2.amount
+      end
+    end
   end
 
   describe 'update' do

--- a/spec/system/payments_spec.rb
+++ b/spec/system/payments_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe "Payments", type: :system do
   let!(:user){ create(:user) }
   let!(:child){ create(:child, user: user) }
+  let!(:plan_1){ create(:plan, item: '保険', amount: 20000, child: child) }
+  let!(:plan_2){ create(:plan, item: '投資', amount: 10000, child: child) }
   before { login(user) }
   describe 'index' do
     let!(:payment_collection){ create(:payment_collection, child: child) }
@@ -74,6 +76,8 @@ RSpec.describe "Payments", type: :system do
 
         fill_in 'payment_collection[payments_attributes][0][item]', with: payment_1.item
         fill_in 'payment_collection[payments_attributes][0][amount]', with: payment_1.amount
+        fill_in 'payment_collection[payments_attributes][1][item]', with: ''
+        fill_in 'payment_collection[payments_attributes][1][amount]', with: ''
         click_on '登録する'
       end
       it 'is successful' do
@@ -85,7 +89,7 @@ RSpec.describe "Payments", type: :system do
         fill_in 'payment_collection[paymented_at]', with: Date.today
 
         # 費目を入力しません
-        # fill_in 'payment_collection[payments_attributes][0][item]', with: payment_1.item
+        fill_in 'payment_collection[payments_attributes][0][item]', with: ''
         fill_in 'payment_collection[payments_attributes][0][amount]', with: payment_1.amount
         click_on '登録する'
       end
@@ -99,21 +103,24 @@ RSpec.describe "Payments", type: :system do
 
         fill_in 'payment_collection[payments_attributes][0][item]', with: payment_1.item
         # 金額を入力しない
-        # fill_in 'payment_collection[payments_attributes][0][amount]', with: payment_1.amount
+        fill_in 'payment_collection[payments_attributes][0][amount]', with: ''
         click_on '登録する'
       end
       it 'is failed' do
         expect(page).to have_content '入金に失敗しました'
       end
     end
-    fcontext 'form with registered plans' do
-      let!(plan_1){ create(:plan, item: '保険', amount: 20000, child: child) }
-      let!(plan_2){ create(:plan, item: '投資', amount: 10000, child: child) }
+    context 'form with registered plans' do
+      before do
+        fill_in 'payment_collection[paymented_at]', with: Date.today
+      end
       it 'can be displayed' do
-        expect(page).to have_content plan_1.item
-        expect(page).to have_content plan_1.amount
-        expect(page).to have_content plan_2.item
-        expect(page).to have_content plan_2.amount
+        expect(page).to have_field 'payment_collection[payments_attributes][0][item]', with: plan_1.item
+        expect(page).to have_field 'payment_collection[payments_attributes][0][amount]', with:  plan_1.amount
+        expect(page).to have_field 'payment_collection[payments_attributes][1][item]', with: plan_2.item
+        expect(page).to have_field 'payment_collection[payments_attributes][1][amount]', with: plan_2.amount
+        expect(page).to have_field 'payment_collection[payments_attributes][2][item]', with: ''
+        expect(page).to have_field 'payment_collection[payments_attributes][2][amount]', with: ''
       end
     end
   end

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Plans", type: :system do
         visit child_plans_path(child.id)
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定一覧'
+        expect(page).to have_content '積立情報設定一覧'
       end
     end
     context 'with registered plan' do
@@ -20,7 +20,7 @@ RSpec.describe "Plans", type: :system do
         visit child_plans_path(child.id)
       end
       it 'can be displayed' do
-        expect(page).to have_content '積立設定一覧'
+        expect(page).to have_content '積立情報設定一覧'
         expect(page).to have_content plan.item
         expect(page).to have_content plan.amount.to_s(:delimited)
       end
@@ -45,7 +45,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定しました'
+        expect(page).to have_content '積立情報設定しました'
         expect(current_path).to eq child_plans_path(child.id)
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is failed' do
         expect(page).to have_content '入力項目を確認してください'
-        expect(page).to have_content '積立設定登録'
+        expect(page).to have_content '積立情報設定登録'
       end
     end
     context 'without amount' do
@@ -76,7 +76,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is failed' do
         expect(page).to have_content '入力項目を確認してください'
-        expect(page).to have_content '積立設定登録'
+        expect(page).to have_content '積立情報設定登録'
       end
     end
     context 'without checking auto payment status' do
@@ -90,7 +90,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定しました'
+        expect(page).to have_content '積立情報設定しました'
         expect(current_path).to eq child_plans_path(child.id)
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定しました'
+        expect(page).to have_content '積立情報設定しました'
         expect(current_path).to eq child_plans_path(child.id)
       end
     end
@@ -140,7 +140,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is failed' do
         expect(page).to have_content '入力項目を確認してください'
-        expect(page).to have_content '積立設定登録'
+        expect(page).to have_content '積立情報設定登録'
       end
     end
   end
@@ -160,7 +160,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定を編集しました'
+        expect(page).to have_content '積立情報設定を編集しました'
         expect(current_path).to eq child_plans_path(child.id)
         expect(page).to have_content plan.item
         expect(page).to have_content add_plan.item
@@ -172,7 +172,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定を編集しました'
+        expect(page).to have_content '積立情報設定を編集しました'
         expect(page).to have_content add_plan.item
         expect(page).to have_no_content plan.item
         expect(page).to have_content plan.amount.to_s(:delimited)
@@ -201,7 +201,7 @@ RSpec.describe "Plans", type: :system do
         find("#delete_button_for_plan_#{delete_plan.id}").click
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定を削除しました'
+        expect(page).to have_content '積立情報設定を削除しました'
         expect(page).to have_no_content delete_plan.item
       end
     end
@@ -211,7 +211,7 @@ RSpec.describe "Plans", type: :system do
         find("#delete_button_for_plan_#{plan.id}").click
       end
       it 'is successful' do
-        expect(page).to have_content '積立設定を削除しました'
+        expect(page).to have_content '積立情報設定を削除しました'
         expect(page).to have_no_content plan.item
         expect(page).to have_content '何もデータはありません'
       end

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Plans", type: :system do
         visit child_plans_path(child.id)
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定一覧'
+        expect(page).to have_content '積立設定一覧'
       end
     end
     context 'with registered plan' do
@@ -20,7 +20,7 @@ RSpec.describe "Plans", type: :system do
         visit child_plans_path(child.id)
       end
       it 'can be displayed' do
-        expect(page).to have_content '入金設定一覧'
+        expect(page).to have_content '積立設定一覧'
         expect(page).to have_content plan.item
         expect(page).to have_content plan.amount.to_s(:delimited)
       end
@@ -45,7 +45,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定しました'
+        expect(page).to have_content '積立設定しました'
         expect(current_path).to eq child_plans_path(child.id)
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is failed' do
         expect(page).to have_content '入力項目を確認してください'
-        expect(page).to have_content '入金設定登録'
+        expect(page).to have_content '積立設定登録'
       end
     end
     context 'without amount' do
@@ -76,7 +76,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is failed' do
         expect(page).to have_content '入力項目を確認してください'
-        expect(page).to have_content '入金設定登録'
+        expect(page).to have_content '積立設定登録'
       end
     end
     context 'without checking auto payment status' do
@@ -90,7 +90,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定しました'
+        expect(page).to have_content '積立設定しました'
         expect(current_path).to eq child_plans_path(child.id)
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定しました'
+        expect(page).to have_content '積立設定しました'
         expect(current_path).to eq child_plans_path(child.id)
       end
     end
@@ -140,7 +140,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is failed' do
         expect(page).to have_content '入力項目を確認してください'
-        expect(page).to have_content '入金設定登録'
+        expect(page).to have_content '積立設定登録'
       end
     end
   end
@@ -160,7 +160,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定を編集しました'
+        expect(page).to have_content '積立設定を編集しました'
         expect(current_path).to eq child_plans_path(child.id)
         expect(page).to have_content plan.item
         expect(page).to have_content add_plan.item
@@ -172,7 +172,7 @@ RSpec.describe "Plans", type: :system do
         click_on '登録する'
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定を編集しました'
+        expect(page).to have_content '積立設定を編集しました'
         expect(page).to have_content add_plan.item
         expect(page).to have_no_content plan.item
         expect(page).to have_content plan.amount.to_s(:delimited)
@@ -201,7 +201,7 @@ RSpec.describe "Plans", type: :system do
         find("#delete_button_for_plan_#{delete_plan.id}").click
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定を削除しました'
+        expect(page).to have_content '積立設定を削除しました'
         expect(page).to have_no_content delete_plan.item
       end
     end
@@ -211,7 +211,7 @@ RSpec.describe "Plans", type: :system do
         find("#delete_button_for_plan_#{plan.id}").click
       end
       it 'is successful' do
-        expect(page).to have_content '入金設定を削除しました'
+        expect(page).to have_content '積立設定を削除しました'
         expect(page).to have_no_content plan.item
         expect(page).to have_content '何もデータはありません'
       end


### PR DESCRIPTION
概要
入金登録時のフォームに入金設定で登録した費目と金額が表示されるようにする。
入金設定を「積立設定」という名称に変える。

仕様
- [ ] 「積立設定」で入力した内容が入金登録時のフォームに表示されること
- [ ] 「入金設定」という文字が表示されないこと

確認方法
RSpecでのテスト。
spec/system/payments_spec.rb
spec/system/plans_spec.rb
![6f50864cdb439504ba02b6add6143800](https://github.com/tomomih217/kokeibo/assets/110954393/e31ca81f-0a8b-48e7-8020-dadecce1951b)
![6987a8aa16a2e476b54f9756272f375f](https://github.com/tomomih217/kokeibo/assets/110954393/e4cea6e5-a7e2-4203-8bc1-f67b8a613806)
