### PR TITLE
Mypage graph

### DIFF
--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -3,6 +3,5 @@ class MypageController < ApplicationController
   def show
     @savings_datas = @child.payments.group(:item).sum(:amount)
     @each_stage_cost = @child.result.each_stage_cost if @child.result.present?
-    
   end
 end

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -58,6 +58,13 @@
         </div>
       </div>
     </div>
+        <div class='my-20'>
+      <%= react_component('features/ResultGraph', { monthlyAmount: @child.plans.sum(:amount), age: @child.result.age, costArray: @child.result.cost_datas_hash.values }) %>
+      <% if @child.result.total_cost > @child.plans.sum(:amount) * @child.result.duration %>
+        <p class='text-red-500 text-center'>在学中に別途資金が必要です。ご注意ください。</p>
+      <% end %>
+    </div>
+    
   <% else %>
     <div class='text-center'>
       <p class='text-center text-amber-dark mb-3'>データはありません</p>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -58,13 +58,15 @@
         </div>
       </div>
     </div>
-        <div class='my-20'>
-      <%= react_component('features/ResultGraph', { monthlyAmount: @child.plans.sum(:amount), age: @child.result.age, costArray: @child.result.cost_datas_hash.values }) %>
-      <% if @child.result.total_cost > @child.plans.sum(:amount) * @child.result.duration %>
-        <p class='text-red-500 text-center'>在学中に別途資金が必要です。ご注意ください。</p>
-      <% end %>
-    </div>
-    
+    <% if @child.result.present? %>
+      <div class='my-20' id='saving_plan_graph'>
+        <%= react_component('features/ResultGraph', { monthlyAmount: @child.plans.sum(:amount), age: @child.result.age, costArray: @child.result.cost_datas_hash.values }) %>
+        <% if @child.result.total_cost > @child.plans.sum(:amount) * @child.result.duration %>
+          <p class='text-red-500 text-center'>在学中に別途資金が必要です。ご注意ください。</p>
+        <% end %>
+      </div>
+    <% end %>
+
   <% else %>
     <div class='text-center'>
       <p class='text-center text-amber-dark mb-3'>データはありません</p>

--- a/spec/system/mypages_spec.rb
+++ b/spec/system/mypages_spec.rb
@@ -71,5 +71,13 @@ RSpec.describe "Mypage", type: :system do
         expect(page).to have_no_selector "#check_for_#{plan_2.id}"
       end
     end
+    fcontext 'with both plans and result' do
+      let!(:result){ create(:result, child: child) }
+      let!(:plan){ create(:plan, child: child) }
+      before { login(user) }
+      it 'can be displayed saving_plan_graph' do
+        expect(page).to have_selector '#saving_plan_graph'
+      end
+    end
   end
 end


### PR DESCRIPTION
概要
ユーザーの安心感のため、マイページに将来的な見通しが目で分かる要素が欲しい。「このまま積立ていったら大丈夫！」という確信に繋がる材料として、将来の見通しがわかるグラフを表示する。

仕様
 - [x] マイページに登録ずみの希望進路をもとに積立推移グラフが表示されること。
 - [x] 希望進路が未登録の場合はグラフが表示されないこと。

確認方法
開発環境での実動作確認。
（RSpec不具合のため）
RSpecのテストは作成している。後日検証。
spec/system/mypages_spec.rb