### PR TITLE
Add: ログイン前のシュミレーション後に会員登録を促すボタンを追加しました。

### DIFF
--- a/app/javascript/components/features/Result.js
+++ b/app/javascript/components/features/Result.js
@@ -3,6 +3,8 @@ import json from '../../../../public/education_cost.json';
 import WithoutTitleCard from '../components/WithoutTitleCard';
 import Text from '../components/Text';
 import ResultGraph from './ResultGraph';
+import Link from '../components/Link';
+import Button from '../components/Button';
 
 const Result = ({ props }) => {
   //積立期間
@@ -70,7 +72,12 @@ const Result = ({ props }) => {
           『令和3年度「教育費負担の実態調査結果」（日本政策金融公庫より・令和3年12月発行）』
         </Text>
       </div>
-
+      <div class='mt-10'>
+        <p class='text-center text-amber-dark'>会員登録をして、教育費を貯めましょう。</p>
+        <Link page='/users/new'>
+          <Button pxSize='3' pySize='2' color='green-300' fontColor='white' roundType='full'>会員登録（無料）</Button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/views/plans/_plan_form.html.erb
+++ b/app/views/plans/_plan_form.html.erb
@@ -13,10 +13,10 @@
           <td class='text-center'><%= f.number_field :amount, class: 'bg-white border-2 border-amber-dark rounded w-2/3 py-2 px-4 text-gray-700 focus:outline-none focus:border-purple-500' %>円</td>
           <td class='text-center pb-5'>
             <%= f.select :payment_day, (1..30).to_a, {include_blank: true}, step: 1000, class: 'bg-white border-2 border-amber-dark rounded py-2 px-4 text-gray-700 focus:outline-none focus:border-purple-500' %>日
-            <div class='mt-1'>
+            <!-- div class='mt-1'>
               <%= f.check_box :is_auto %>
               <%= f.label :is_auto, '自動で入金', class: 'text-amber-dark' %>
-            </div>
+            </div -->
           </td>
         </tr>
       <% end %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,5 +1,9 @@
 <h1 class='mb-5 text-3xl text-amber-dark text-center'>積立情報設定一覧</h1>
 
+<% if @child.result.present? %>
+  <p class='text-amber-dark text-center mb-5'>(目安積立額：　<%= @child.result.cost_per_month.to_s(:delimited) %>円)</p>
+<% end %>
+
 <% if @child.plans.empty? %>
   <div class='text-center'>
     <p class='text-amber-dark'>何もデータはありません</p>
@@ -8,12 +12,13 @@
     </div>
   </div>
 <% else %>
+   <p class='text-amber-dark text-center text-xl mb-5'>積立額：　<%= @child.plans.sum(:amount).to_s(:delimited) %>円</p>
   <table class='m-auto'>
     <thead class='bg-yellow-300'>
       <th class='px-5 py-3'>項目</th>
       <th class='px-5 py-3'>金額</th>
       <th class='px-5 py-3'>入金予定日</th>
-      <th class='px-5 py-3'>自動入金設定</th>
+      <!--th class='px-5 py-3'>自動入金設定</th -->
       <th></th>
     </thead>
     <tbody class='text-center bg-yellow-100'>
@@ -22,7 +27,7 @@
           <td class='px-5 py-3'><%= plan.item %></td>
           <td class='px-5 py-3'><%= plan.amount.to_s(:delimited) %>円</td>
           <td class='px-5 py-3'>毎月<%= plan.payment_day %>日</td>
-          <td class='px-5 py-3'><%= plan.is_auto ? 'on' : 'off' %></td>
+          <!-- td class='px-5 py-3'><%= plan.is_auto ? 'on' : 'off' %></td -->
           <td class='px-5 py-3'>
             <%= link_to '削除', plan_path(plan.id), method: :delete, id: "delete_button_for_plan_#{plan.id}", class: 'px-2 py-2 bg-red-500 text-white rounded-md shadow-md hover:shadow-sm' %>
           </td>

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Plans", type: :system do
       end
       it 'is successful' do
         expect(page).to have_content '積立情報設定一覧'
+        expect(page).to have_content child.result.cost_per_month.to_s(:delimited)
       end
     end
     context 'with registered plan' do
@@ -40,7 +41,7 @@ RSpec.describe "Plans", type: :system do
         fill_in 'plan_form[plans_attributes][0][item]', with: plan.item
         fill_in 'plan_form[plans_attributes][0][amount]', with: plan.amount
         select plan.payment_day, from: 'plan_form[plans_attributes][0][payment_day]'
-        check 'plan_form_plans_attributes_0_is_auto'
+        # check 'plan_form_plans_attributes_0_is_auto'
 
         click_on '登録する'
       end
@@ -55,7 +56,7 @@ RSpec.describe "Plans", type: :system do
         # fill_in 'plan_form[plans_attributes][0][item]', with: plan.item
         fill_in 'plan_form[plans_attributes][0][amount]', with: plan.amount
         select plan.payment_day, from: 'plan_form[plans_attributes][0][payment_day]'
-        check 'plan_form_plans_attributes_0_is_auto'
+        # check 'plan_form_plans_attributes_0_is_auto'
 
         click_on '登録する'
       end
@@ -70,7 +71,7 @@ RSpec.describe "Plans", type: :system do
         # 金額を入力しない
         # fill_in 'plan_form[plans_attributes][0][amount]', with: plan.amount
         select plan.payment_day, from: 'plan_form[plans_attributes][0][payment_day]'
-        check 'plan_form_plans_attributes_0_is_auto'
+        # check 'plan_form_plans_attributes_0_is_auto'
 
         click_on '登録する'
       end
@@ -99,7 +100,7 @@ RSpec.describe "Plans", type: :system do
         fill_in 'plan_form[plans_attributes][0][item]', with: plan.item
         fill_in 'plan_form[plans_attributes][0][amount]', with: plan.amount
         select plan.payment_day, from: 'plan_form[plans_attributes][0][payment_day]'
-        check 'plan_form_plans_attributes_0_is_auto'
+        # check 'plan_form_plans_attributes_0_is_auto'
 
         fill_in 'plan_form[plans_attributes][1][item]', with: plan_1.item
         fill_in 'plan_form[plans_attributes][1][amount]', with: plan_1.amount
@@ -129,12 +130,12 @@ RSpec.describe "Plans", type: :system do
         # fill_in 'plan_form[plans_attributes][1][item]', with: plan_1.item
         fill_in 'plan_form[plans_attributes][1][amount]', with: plan_1.amount
         select plan_1.payment_day, from: 'plan_form[plans_attributes][1][payment_day]'
-        check 'plan_form_plans_attributes_1_is_auto'
+        # check 'plan_form_plans_attributes_1_is_auto'
 
         fill_in 'plan_form[plans_attributes][2][item]', with: plan_2.item
         fill_in 'plan_form[plans_attributes][2][amount]', with: plan_2.amount
         select plan_2.payment_day, from: 'plan_form[plans_attributes][2][payment_day]'
-        check 'plan_form_plans_attributes_2_is_auto'
+        # check 'plan_form_plans_attributes_2_is_auto'
 
         click_on '登録する'
       end


### PR DESCRIPTION
概要
機能としては不可欠ではないものの、後回しにしてきた修正箇所を修正する。

仕様
- [x] 積立情報設定一覧に「目安の月額」が表示されること。
- [x] 積立情報の「自動入金」を非表示であること。
- [x] ログイン前のシュミレーションの結果表示の後にログインへ誘導するボタンが表示されること。

確認方法
開発環境での実動作テスト。
RSpecのテストコードは作成済み。
spec/system/plans_spec.rb