### PR TITLE
Improve: tailwindcssのカスタムカラーパレットの設定を変更し、フラッシュメッセージの色が反映されるようにしました。

### DIFF
--- a/app/javascript/packs/tailwind.config.js
+++ b/app/javascript/packs/tailwind.config.js
@@ -27,15 +27,20 @@ module.exports = {
         'sans-serif',
       ]
     },
-/*    colors: {
-     white: colors.white,
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      success: colors.emerald,
+      info: colors.cyan,
+      warning: colors.orange,
+      danger: colors.red,
+      white: colors.white,
+      gray: colors.gray,
       blue: colors.blue,
       green: colors.green,
-      info: colors.cyan,
-      success: colors.emerald,
-      warning: colors.orange,
-      danger: colors.red, 
-    },*/
+      yellow: colors.yellow,
+      red: colors.red
+    },
     extend: {
       colors: {
         'amber-dark': '#5C5446',
@@ -43,11 +48,7 @@ module.exports = {
         'amber-card': '#FFF6C6',
         'amber-vivid': '#FE6B01',
         'submenu': '#FFFEF3',
-        info: colors.cyan,
-        success: colors.emerald,
-        warning: colors.orange,
-        danger: colors.red,
-      },
+      }
     },
   },
 }

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="bg-<%= message_type %>-100 border-l-4 border-<%= message_type %>-500 text-<%= message_type %>-700 p-4" role="alert">
+  <div id='flash_message' class="bg-<%= message_type %>-100 border-l-4 border-<%= message_type %>-500 text-<%= message_type %>-700 p-4" role="alert">
     <p><%= message %></p>
   </div>
 <% end %>

--- a/spec/system/flash_messages_spec.rb
+++ b/spec/system/flash_messages_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'FlashMessage', type: :system do
+  let!(:user) { create(:user) }
+  let(:wrong_user){ build(:user, password: '') }
+  describe 'of success type' do
+    before { login(user) }
+    context 'is green' do
+      expect(find('#flash_message')).to have_css '.bg-success-100'
+    end
+  end
+  describe 'of danger type' do
+    before { login(wrong_user) }
+    context 'is red' do
+      expect(find('#flash_message')).to have_css '.bg-danger-100'
+    end
+  end
+end


### PR DESCRIPTION
概要
フラッシュメッセージの色設定が反映されていないので修正する。

仕様
- [x] 成功の処理なら緑色で表示されること。
- [x] 失敗なら赤色で表示されること。
- [x] 警告なら黄色で表示されること。