### PR TITLE
Destroy user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,9 @@
 class UsersController < ApplicationController
   layout 'before_login_layout'
   skip_before_action :require_login, only: %i[new confirm create complete]
-  skip_before_action :delete_session, only: %i[create]
+  skip_before_action :delete_session, only: %i[create destroy]
   skip_before_action :get_current_child
-  after_action :delete_session, only: %i[create]
+  after_action :delete_session, only: %i[create destroy]
 
   def new
     @form = UserForm.new
@@ -30,6 +30,11 @@ class UsersController < ApplicationController
   end
 
   def complete; end
+
+  def destroy
+    User.destroy!(current_user.id)
+    redirect_to root_path, success: '退会が完了しました。ご利用ありがとうございました。'
+  end
 
   private
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,8 +32,8 @@ class UsersController < ApplicationController
   def complete; end
 
   def destroy
-    User.destroy!(current_user.id)
-    redirect_to root_path, success: '退会が完了しました。ご利用ありがとうございました。'
+    User.destroy(current_user.id)
+    redirect_to login_path, success: '退会が完了しました。ご利用ありがとうございました。'
   end
 
   private

--- a/app/views/shared/_submenu.html.erb
+++ b/app/views/shared/_submenu.html.erb
@@ -16,7 +16,9 @@
       <li class="px-5 py-3 hover:bg-gray-100<%= ' underline bg-gray-200' if current_page?(new_child_path) %>">お子様情報追加</li>
     <% end %>
     <!--li class='mb-3'>パートナー追加</li>
-    <li class='mb-3'>会員情報変更</li>
-    <li class='mb-3'>退会手続き</li-->
+    <li class='mb-3'>会員情報変更</li-->
+    <%= link_to user_path(current_user), method: :delete, data: { confirm: '退会すると積立情報が消えてしまいます。本当に退会しますか？' } do %>
+      <li class='px-5 py-3 hover:bg-gray-100'>退会手続き</li>
+    <% end %>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get '/privacypolicy', to: redirect('/')
   get '/termandcondition', to: redirect('/')
 
-  resources :users, only: %i[new create]
+  resources :users, only: %i[new create destroy]
   namespace :users do
     post 'confirm'
     get 'complete'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Users', type: :system do
       end
       it 'is successful' do
         expect(page).to have_content '退会が完了しました。ご利用ありがとうございました。'
-        expect(current_path).to eq root_path
+        expect(current_path).to eq login_path
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -120,4 +120,21 @@ RSpec.describe 'Users', type: :system do
       end
     end
   end
+
+  describe 'destroy' do
+    let!(:user){ create(:user) }
+    let!(:child){ create(:child, user: user) }
+    fcontext 'after login' do
+      before do 
+        login(user)
+        page.accept_confirm do
+          click_on '退会'
+        end
+      end
+      it 'is successful' do
+        expect(page).to have_content '退会が完了しました。ご利用ありがとうございました。'
+        expect(current_path).to eq root_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
概要
ユーザーが自ら退会の手続きができる機能を追加する。

仕様
- [x] マイページの「退会」ボタンから退会手続きができること。
- [x] 退会処理が完了したら「退会が完了しました。ご利用ありがとうございました。」と表示されること。

確認方法
RSpecによるテスト。
spec/system/us
![038ee9f1a78f3cc800477ceba2c33c47](https://github.com/tomomih217/kokeibo/assets/110954393/216d8268-22e3-4ff9-be7a-f2d3531d9a59)
ers_spec.rb
