### PR TITLE
Fix code

### DIFF
--- a/app/form/PlanForm.rb
+++ b/app/form/PlanForm.rb
@@ -29,7 +29,7 @@ class PlanForm
       end
     end
     true
-  rescue StandardError => e
+  rescue StandardError
     false
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,7 @@ module ApplicationHelper
     options.push('選択してください')
     options.push('出産前')
     options += (0..18).to_a.map { |x| x.to_s + '才' }
+    options
   end
 
   def living_alone_funds_options
@@ -11,6 +12,7 @@ module ApplicationHelper
     options.push('選択してください')
     options.push('仕送りの予定はない')
     options += (1..20).map { |x| x.to_s + '万円' }
+    options
   end
 
   def calender_year(year=Date.today.year)

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -53,13 +53,6 @@ class Child < ApplicationRecord
 
   def duration(age)
     (age - result.age) * 12
-=begin
-    t = Date.today.year * 12 + Date.today.month
-    culculated_date = (Date.today + age.years)
-    s_day = Date.new(culculated_date.year, 3, 31)
-    s = culculated_date.year * 12 + 3
-    s - t
-=end
   end
 
   def culculated_amount(age)
@@ -111,6 +104,4 @@ class Child < ApplicationRecord
       stamps.create(attributes)
     end
   end
-
-        
 end

--- a/app/models/payment_collection.rb
+++ b/app/models/payment_collection.rb
@@ -1,7 +1,7 @@
 class PaymentCollection < ApplicationRecord
   belongs_to :child
   has_many :payments, dependent: :destroy
-  accepts_nested_attributes_for :payments, reject_if: :all_blank, allow_destroy: :true
+  accepts_nested_attributes_for :payments, reject_if: :all_blank, allow_destroy: true
 
   validates :paymented_at, presence: true
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -90,14 +90,9 @@ class Result < ApplicationRecord
     ageRange = age_range
 
     schoolTypes.each do |schoolType|
-      total = 0
       school_type = schoolType.underscore.to_sym
       next if unselected?(school_type)
       
-      #ageRange[school_type].each do |target_age|
-      #  data = json_datas[schoolType][send(school_type)][target_age]
-      #  total += data if target_age.gsub(/[^\d]/, "").to_i >= age
-      #end
       total = ageRange[school_type].sum { |target_age| json_datas[schoolType][send(school_type)][target_age] if target_age.gsub(/[^\d]/, "").to_i >= age }
       cost_datas[school_type] = total
     end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -52,6 +52,7 @@ class Result < ApplicationRecord
       high_school
       university
     ]
+    schoolTypes
   end
 
   def age_range
@@ -66,7 +67,7 @@ class Result < ApplicationRecord
     if unselected?('kindergarten')
       array = []
       (from_age_for_nursery_school..5).each do |target_age|
-        array.push("age#{target_age.to_s}")
+        array.push("age#{target_age}")
       end
       ageRange[:nursery_school] = array
       ageRange[:kindergarten] = []

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,19 @@
 <% flash.each do |message_type, message| %>
-  <div id='flash_message' class="bg-<%= message_type %>-100 border-l-4 border-<%= message_type %>-500 text-<%= message_type %>-700 p-4" role="alert">
-    <p><%= message %></p>
-  </div>
+  <% if message_type == 'success' %>
+    <div id='flash_message' class="bg-success-100 border-l-4 border-success-500 text-success-700 p-4" role="alert">
+      <p><%= message %></p>
+    </div>
+  <% elsif message_type == 'danger' %>
+    <div id='flash_message' class="bg-danger-100 border-l-4 border-danger-500 text-danger-700 p-4" role="alert">
+      <p><%= message %></p>
+    </div>
+  <% elsif message_type == 'warning' %>
+    <div id='flash_message' class="bg-warning-100 border-l-4 border-warning-500 text-warning-700 p-4" role="alert">
+      <p><%= message %></p>
+    </div>
+  <% elsif message_type == 'info' %>
+    <div id='flash_message' class="bg-info-100 border-l-4 border-info-500 text-info-700 p-4" role="alert">
+      <p><%= message %></p>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,19 +1,13 @@
 <% flash.each do |message_type, message| %>
-  <% if message_type == 'success' %>
-    <div id='flash_message' class="bg-success-100 border-l-4 border-success-500 text-success-700 p-4" role="alert">
-      <p><%= message %></p>
-    </div>
-  <% elsif message_type == 'danger' %>
-    <div id='flash_message' class="bg-danger-100 border-l-4 border-danger-500 text-danger-700 p-4" role="alert">
-      <p><%= message %></p>
-    </div>
-  <% elsif message_type == 'warning' %>
-    <div id='flash_message' class="bg-warning-100 border-l-4 border-warning-500 text-warning-700 p-4" role="alert">
-      <p><%= message %></p>
-    </div>
-  <% elsif message_type == 'info' %>
-    <div id='flash_message' class="bg-info-100 border-l-4 border-info-500 text-info-700 p-4" role="alert">
-      <p><%= message %></p>
-    </div>
-  <% end %>
+  <% class_name = case message_type
+                   when 'success' then 'bg-success-100 border-l-4 border-success-500 text-success-700 p-4'
+                   when 'danger' then 'bg-danger-100 border-l-4 border-danger-500 text-danger-700 p-4'
+                   when 'warning' then 'bg-warning-100 border-l-4 border-warning-500 text-warning-700 p-4'
+                   when 'info' then 'bg-info-100 border-l-4 border-info-500 text-info-700 p-4'
+                   else ''
+                   end %>
+  
+  <div id='flash_message' class="<%= class_name %>" role="alert">
+    <p><%= message %></p>
+  </div>
 <% end %>

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :result do
     age { 0 }
     nursery_school { 'private' }
+    from_age_for_nursery_school { 1 }
     kindergarten { 'private' }
     primary_school { 'public' }
     junior_high_school { 'public' }

--- a/spec/system/flash_messages_spec.rb
+++ b/spec/system/flash_messages_spec.rb
@@ -2,17 +2,22 @@ require 'rails_helper'
 
 RSpec.describe 'FlashMessage', type: :system do
   let!(:user) { create(:user) }
-  let(:wrong_user){ build(:user, password: '') }
-  describe 'of success type' do
+  let!(:child){ create(:child, user: user) }
+  let(:wrong_user){ build(:user, name: '') }
+  context 'of success type' do
     before { login(user) }
-    context 'is green' do
-      expect(find('#flash_message')).to have_css '.bg-success-100'
+    it 'is green' do  
+      expect(page).to have_css '.bg-success-100'
+      expect(page).to have_css '.border-success-500'
+      expect(page).to have_css '.text-success-700'
     end
   end
-  describe 'of danger type' do
+  context 'of danger type' do
     before { login(wrong_user) }
-    context 'is red' do
-      expect(find('#flash_message')).to have_css '.bg-danger-100'
+    it 'is red' do
+      expect(page).to have_css '.bg-danger-100'
+      expect(page).to have_css '.border-danger-500'
+      expect(page).to have_css '.text-danger-700'
     end
   end
 end

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Simulations", type: :system do
           within '.form-nursery_school-group' do
             find('label', text: '私立').click
           end
+          select "#{result.from_age_for_nursery_school}才", from: 'result[from_age_for_nursery_school]'
           within '.form-kindergarten-group' do
             find('label', text: '私立').click
           end
@@ -30,8 +31,8 @@ RSpec.describe "Simulations", type: :system do
             find('label', text: '私立理系').click
           end
           find("option[value='#{result.living_alone_funds}万円']").select_option
-          click_button 'シュミレーション結果'
-          click_button '登録する'
+          click_on 'シュミレーション結果'
+          click_on '登録する'
         end
         it 'is successful' do
           expect(page).to have_content '希望進路を登録しました'
@@ -41,21 +42,19 @@ RSpec.describe "Simulations", type: :system do
     end
     
     describe 'update' do
-      describe 'create' do
-        let!(:result){ create(:result, child: child) }
-        before { visit edit_simulation_path(result) }
-        context 'with all attributes' do
-          before do
-            within '.form-high_school-group' do
-              find('label', text: '公立').click
-            end
-            click_button 'シュミレーション結果'
-            click_button '編集する'
+      let!(:result){ create(:result, child: child) }
+      before { visit edit_simulation_path(result) }
+      context 'with all attributes' do
+        before do
+          within '.form-high_school-group' do
+            find('label', text: '公立').click
           end
-          it 'is successful' do
-            expect(page).to have_content '希望進路を編集しました'
-            expect(current_path).to eq child_results_path(child)
-          end
+          click_button 'シュミレーション結果'
+          click_on '編集する'
+        end
+        it 'is successful' do
+          expect(page).to have_content '希望進路を編集しました'
+          expect(current_path).to eq mypage_path
         end
       end
     end
@@ -69,7 +68,7 @@ RSpec.describe "Simulations", type: :system do
         expect(page).to have_link '希望進路の登録', href: new_child_simulation_path(child)
       end
     end
-    fcontext 'with registerd result' do
+    context 'with registerd result' do
       let!(:result){ create(:result, child: child) }
       before { visit child_results_path(child) }
       it 'has button to link to simulation#edit' do
@@ -95,6 +94,7 @@ RSpec.describe "Simulations", type: :system do
         within '.form-nursery_school-group' do
           find('label', text: '私立').click
         end
+        select "#{result.from_age_for_nursery_school}才", from: 'result[from_age_for_nursery_school]'
         within '.form-kindergarten-group' do
           find('label', text: '私立').click
         end
@@ -115,9 +115,9 @@ RSpec.describe "Simulations", type: :system do
       end
       it 'is successful' do
         expect(current_path).to eq child_result_path(child) # シュミレーション結果画面への遷移を確認
-        expect(page).to have_content "#{result.age}〜18才まで" # 積立期間が表示されること
-        expect(page).to have_content '総額： 22,015,376円' # 積立総額が表示されること
-        expect(page).to have_content '月額　約101,923円' # 月額の積立金額が表示されること
+        expect(page).to have_content "0〜18才まで" # 積立期間が表示されること
+        expect(page).to have_content '総額： 18,685,376円' # 積立総額が表示されること
+        expect(page).to have_content '月額　約86,506円' # 月額の積立金額が表示されること
         expect(page).to have_selector 'canvas' # グラフが表示されること
       end
     end
@@ -125,21 +125,7 @@ RSpec.describe "Simulations", type: :system do
       before do
         # ageを選択しない
         # find("option[value='#{result.age}才']").select_option
-        within '.form-nursery_school-group' do
-          find('label', text: '私立').click
-        end
-        within '.form-kindergarten-group' do
-          find('label', text: '私立').click
-        end
-        within '.form-primary_school-group' do
-          find('label', text: '公立').click
-        end
-        within '.form-junior_high_school-group' do
-          find('label', text: '公立').click
-        end
-        within '.form-high_school-group' do
-          find('label', text: '私立').click
-        end
+        
         within '.form-university-group' do
           find('label', text: '私立理系').click
         end
@@ -218,7 +204,7 @@ RSpec.describe "Simulations", type: :system do
     before { visit edit_simulation_path(result) }
     context 'with registerd result content' do
       it 'can be displayed' do
-        expect(page).to have_field 'result[age]', with: result.age
+        expect(page).to have_field 'result[age]', with: '出産前'
         within '.form-nursery_school-group' do
           expect(page).to have_checked_field 'private'
         end
@@ -249,8 +235,8 @@ RSpec.describe "Simulations", type: :system do
       end
       it 'is successful' do
         expect(current_path).to eq child_result_path(child) # シュミレーション結果画面への遷移を確認
-        expect(page).to have_content "#{result.age}〜18才まで" # 積立期間が表示されること
-        expect(page).to have_content '総額： 17.072,091円' # 積立総額が表示されること
+        expect(page).to have_content "0〜18才まで" # 積立期間が表示されること
+        expect(page).to have_content '総額： 17,072,091円' # 積立総額が表示されること
         expect(page).to have_content '月額　約79,037円' # 月額の積立金額が表示されること
         expect(page).to have_selector 'canvas' # グラフが表示されること
       end
@@ -258,7 +244,7 @@ RSpec.describe "Simulations", type: :system do
     context 'without age' do
       before do
         # ageを選択しない
-        find("option[value='選択してください']").select_option
+        select '選択してください', from: 'result[age]'
         click_button 'シュミレーション結果'
       end
       it 'is failed' do
@@ -269,7 +255,7 @@ RSpec.describe "Simulations", type: :system do
     context 'without selected living_alone_fund' do
       before do
         # 仕送り金額を選択しない
-        find("option[value='選択してください']").select_option
+        select '選択してください', from: 'result[living_alone_funds]'
         click_button 'シュミレーション結果'
       end
       it 'is failed' do

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "Simulations", type: :system do
             expect(current_path).to eq child_results_path(child)
           end
         end
+      end
     end
   end
   
@@ -217,7 +218,7 @@ RSpec.describe "Simulations", type: :system do
     before { visit edit_simulation_path(result) }
     context 'with registerd result content' do
       it 'can be displayed' do
-        expect(page).to have_field 'result[age]' with: result.age
+        expect(page).to have_field 'result[age]', with: result.age
         within '.form-nursery_school-group' do
           expect(page).to have_checked_field 'private'
         end


### PR DESCRIPTION
概要
本番リリース前にコードの冗長化を解消させる。RubocopとChat-GPTを使用する。
フラッシュメッセージが本番環境ではTailwind-cssが当たらない現象についても、クラス名を式展開しない方法で実装して解消を図る。

仕様
- [x] フラッシュメッセージに色がついていること。
- [x] Rubocopでのエラーが解消されていること。

確認方法
Rubocopによるエラーチェック及びRSpecによるテスト。