### PR TITLE
Add: ログアウトせずに画面を閉じた後トップにアクセスするとマイページに遷移するようにしました。

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,5 +2,7 @@ class TopController < ApplicationController
   skip_before_action :require_login
   skip_before_action :get_current_child
 
-  def index; end
+  def index
+    redirect_to mypage_path if current_user
+  end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,7 +1,7 @@
 class Child < ApplicationRecord
   belongs_to :user
   has_many :plans, dependent: :destroy
-  has_one :result
+  has_one :result, dependent: :destroy
   has_many :payment_collections, dependent: :destroy
   has_many :payments, through: :payment_collections
   has_many :stamps, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  has_many :children
-  has_many :contacts
+  has_many :children, dependent: :destroy
+  has_many :contacts, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
   # 新規登録かパスワード変更の時に以下のバリデーションを適用する。

--- a/spec/system/mypages_spec.rb
+++ b/spec/system/mypages_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe 'Mypage', type: :system do
         expect(page).to have_no_link '希望進路を登録する'
         expect(page).to have_content '高校入学時'
         expect(page).to have_content child.result.each_stage_cost[:high_school_cost].to_s(:delimited)
-        expect(page).to have_content child.culculated_amount(15).to_s(:delimited)
-        expect(page).to have_content (child.result.each_stage_cost[:high_school_cost] - child.culculated_amount(15)).to_s(:delimited)
+        expect(page).to have_content child.decorate.hold_amount(15)
+        # expect(page).to have_content (child.result.each_stage_cost[:high_school_cost] - child.culculated_amount(15)).to_s(:delimited)
         expect(page).to have_content '大学入学時'
         expect(page).to have_content child.result.each_stage_cost[:university_cost].to_s(:delimited)
-        expect(page).to have_content child.culculated_amount(18).to_s(:delimited)
-        expect(page).to have_content (child.result.each_stage_cost[:university_cost] - child.culculated_amount(18)).to_s(:delimited)
+        expect(page).to have_content child.decorate.hold_amount(18)
+        # expect(page).to have_content (child.result.each_stage_cost[:university_cost] - child.culculated_amount(18)).to_s(:delimited)
       end
     end
     context 'with payed amount in this month' do
@@ -153,6 +153,30 @@ RSpec.describe 'Mypage', type: :system do
       end
       it 'can be display mypage' do
         expect(current_path).to eq mypage_path(child)
+      end
+    end
+  end
+
+  describe 'is rendered' do
+    let!(:user) { create(:user) }
+    let!(:child) { create(:child, user: user) }
+    context 'when access top page without logout' do
+      before do
+        login(user)
+        visit root_path
+      end
+      it 'is successful' do
+        expect(current_path).to eq mypage_path
+      end
+    end
+    context 'when access top page after logout' do
+      before do
+        login(user)
+        click_button 'ログアウト'
+        visit root_path
+      end
+      it 'is failed' do
+        expect(current_path).to eq root_path
       end
     end
   end


### PR DESCRIPTION
概要
ログイン後、ログアウトせずにページを閉じると、次にページにアクセスした際にログインしようとするとIDとパスワードは合っているはずなのにエラーが返される。何度も入力するとログインできる。

仕様
- [x] ログイン情報が残っている場合、トップにアクセスした際にマイページに遷移すること

確認方法
RSpecによるテスト。
spec/system/mypage_spec.rb
![3cc7132aba000465c6be52d2182c5760](https://github.com/tomomih217/kokeibo/assets/110954393/bd95715d-91a9-4266-b582-1c6af2f4e7b7)
